### PR TITLE
Container env SERVER_PASS -> proxy_pass line

### DIFF
--- a/nginx.tmpl
+++ b/nginx.tmpl
@@ -172,6 +172,9 @@ upstream {{ $upstream_name }} {
 {{/* Get the VIRTUAL_ROOT By containers w/ use fastcgi root */}}
 {{ $vhost_root := or (first (groupByKeys $containers "Env.VIRTUAL_ROOT")) "/var/www/public" }}
 
+{{/* Get the SERVER_PASS By containers e.g. proxy_pass..., grpc_pass..., fastcgi_pass... */}}
+{{ $server_pass := or ($container.Env.SERVER_PASS) "" }}
+
 
 {{/* Get the first cert name defined by containers w/ the same vhost */}}
 {{ $certName := (first (groupByKeys $containers "Env.CERT_NAME")) }}
@@ -273,7 +276,9 @@ server {
 	{{ end }}
 
 	location / {
-		{{ if eq $proto "uwsgi" }}
+		{{ if ne $server_pass "" }}
+		{{ $server_pass }};
+		{{ else if eq $proto "uwsgi" }}
 		include uwsgi_params;
 		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ else if eq $proto "fastcgi" }}
@@ -320,7 +325,9 @@ server {
 	{{ end }}
 
 	location / {
-		{{ if eq $proto "uwsgi" }}
+		{{ if ne $server_pass "" }}
+		{{ $server_pass }};
+		{{ else if eq $proto "uwsgi" }}
 		include uwsgi_params;
 		uwsgi_pass {{ trim $proto }}://{{ trim $upstream_name }};
 		{{ else if eq $proto "fastcgi" }}
@@ -359,3 +366,4 @@ server {
 
 {{ end }}
 {{ end }}
+


### PR DESCRIPTION
Adds a container env variable `SERVER_PASS` 
to replace the `proxy_pass` line
e.g.
```
SERVER_PASS='proxy_pass http://container_name:8080'
SERVER_PASS='fastcgi_pass fastcgi://container_name:8080'
SERVER_PASS='grpc_pass grpc://container_name:8080'
```
Note: This is not using upstream_name